### PR TITLE
Fixed: Alt text issue by changing dynamic alt text to constant alt text

### DIFF
--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -31,7 +31,7 @@ export default function Tab(props: Props) {
         const label = optionLabels && optionLabels[opt] ? optionLabels[opt] : opt;
         return (
           <div className={cx("Tab-option", "muted", { active: opt === option })} onClick={() => onClick(opt)} key={opt}>
-            {icons && icons[opt] && <img className="Tab-option-icon inline" src={icons[opt]} alt={String(option)} />}
+            {icons && icons[opt] && <img className="Tab-option-icon inline" src={icons[opt]} alt={label} />}
             {label}
           </div>
         );


### PR DESCRIPTION
# Description

The current implementation of the tab images has a bug where the alt text dynamically changes based on the selected tab. This causes accessibility issues as the alt text does not accurately describe each image. The following changes have been made to fix this issue:

## Issue with Dynamic Alt Text

When any Tab is selected, the alt text for all images changes to the selected Tab label. This is illustrated in the screenshots below.


- 	Image 1: Issue with alt text
<img width="436" alt="Issue" src="https://github.com/ashwinangadi/gmx-interface/assets/115735672/f23bc62c-d444-4ea1-a022-a57695ac8597">


- 	Image 2: Fixed Alt Text
<img width="475" alt="Fixed-Issus" src="https://github.com/ashwinangadi/gmx-interface/assets/115735672/e64c9f0e-1756-408c-a181-15b7712ea08b">


##  Solution

The alt text for each tab image is now constant and descriptive, ensuring it accurately represents the content of the image regardless of the selected tab. This fix enhances accessibility and provides a better user experience.


## Link to Changes

[Link to the fork and specific branch with the changes](https://github.com/ashwinangadi/gmx-interface/tree/fix-alt-text-issue)

## Additional Notes

Please review the changes and consider merging them into the main project. This fix addresses the accessibility concerns related to the alt text for tab images.
